### PR TITLE
tools/waveplay.c: fix heap leakage

### DIFF
--- a/tools/timer_wakeup.c
+++ b/tools/timer_wakeup.c
@@ -242,7 +242,8 @@ setup_sound(struct snd *snd, struct snd_config *cfg)
 	struct snd_parameters p;
 
 	/* get allowed parameters */
-	fd = snd_device_open(0, 0, cfg->flags & SND_INPUT | SND_NONBLOCK);
+	fd = snd_device_open(cfg->card, cfg->device,
+			cfg->flags & SND_INPUT | SND_NONBLOCK);
 	if (fd == -1)
 		return -1;
 	snd_params_init(fd, &p);

--- a/tools/waveplay.c
+++ b/tools/waveplay.c
@@ -318,6 +318,7 @@ run(struct file *files,        unsigned int files_count, unsigned int card,
 
 _cleanup:
 	free(mix_dst);
+	free(mix_sum);
 	free(buffer);
 #if defined(TIMER_WAKEUP) || defined(DEADLINE_WAKEUP)
 	snd_timer_close(&snd_timer, &pcm);


### PR DESCRIPTION
thanks for the project
update a minor change to remove leaks

checked by valgrind --leak-check=full ./tools/waveplay ...

**Before:**
==12897== Memcheck, a memory error detector
==12897== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==12897== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==12897== Command: ./waveplay -c 1 -d 0 /home/giant/Music/piano2.wav
==12897== 
Channels: 2, 48000 Hz, 16-bits, Access RW
==12897== 
==12897== HEAP SUMMARY:
==12897==     in use at exit: 8,192 bytes in 1 blocks
==12897==   total heap usage: 7 allocs, 6 frees, 22,080 bytes allocated
==12897== 
==12897== 8,192 bytes in 1 blocks are definitely lost in loss record 1 of 1
==12897==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==12897==    by 0x109618: run (in /home/giant/code/audio/github/simplesound/tools/waveplay)
==12897==    by 0x109ACA: main (in /home/giant/code/audio/github/simplesound/tools/waveplay)
==12897== 
==12897== LEAK SUMMARY:
==12897==    definitely lost: 8,192 bytes in 1 blocks
==12897==    indirectly lost: 0 bytes in 0 blocks
==12897==      possibly lost: 0 bytes in 0 blocks
==12897==    still reachable: 0 bytes in 0 blocks
==12897==         suppressed: 0 bytes in 0 blocks
==12897== 
==12897== For counts of detected and suppressed errors, rerun with: -v
==12897== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)

**After:**
==12929== Memcheck, a memory error detector
==12929== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==12929== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==12929== Command: ./waveplay -c 1 -d 0 /home/giant/Music/piano2.wav
==12929== 
Channels: 2, 48000 Hz, 16-bits, Access RW
==12929== 
==12929== HEAP SUMMARY:
==12929==     in use at exit: 0 bytes in 0 blocks
==12929==   total heap usage: 7 allocs, 7 frees, 22,080 bytes allocated
==12929== 
==12929== All heap blocks were freed -- no leaks are possible
==12929== 
==12929== For counts of detected and suppressed errors, rerun with: -v
==12929== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
